### PR TITLE
Work around corrupt/inconsistent file names.

### DIFF
--- a/pan/tasks/decoder.cc
+++ b/pan/tasks/decoder.cc
@@ -61,7 +61,8 @@ Decoder :: enqueue (TaskArticle                     * task,
                     const strings_t                 & input_files,
                     const TaskArticle::SaveMode     & save_mode,
                     const TaskArticle::SaveOptions  & options,
-                    const StringView                & filename)
+                    const StringView                & filename,
+                    const Article                   & article)
 {
   disable_progress_update ();
 
@@ -71,6 +72,7 @@ Decoder :: enqueue (TaskArticle                     * task,
   this->save_mode = save_mode;
   this->options = options;
   this->attachment_filename = filename;
+  this->article_subject = article.subject;
 
   mark_read = false;
 
@@ -149,7 +151,12 @@ Decoder :: do_work()
       {
 
         if (was_cancelled()) break;
-        if ((res = UULoadFileWithPartNo (const_cast<char*>(it->c_str()), 0, 0, ++i)) != UURET_OK) {
+        const char *global_subject = NULL;
+        // In SAVE_ALL mode, article_subject is the subject from the NZB file, if known
+        if (options == TaskArticle::SAVE_ALL && !article_subject.empty()) {
+          global_subject = article_subject.c_str();
+        }
+        if ((res = UULoadFileWithPartNo (const_cast<char*>(it->c_str()), 0, 0, ++i, global_subject)) != UURET_OK) {
           g_snprintf(buf, bufsz,
                      _("Error reading from %s: %s"),
                      it->c_str(),
@@ -171,8 +178,8 @@ Decoder :: do_work()
       {
         // skip all other attachments in SAVE_AS mode (single attachment download)
         /// DBG why is this failing if article isn't cached????
-        if (!attachment_filename.empty())
-          if(strcmp(item->filename, attachment_filename.str) != 0 && options == TaskArticle::SAVE_AS) continue;
+        if (options == TaskArticle::SAVE_AS && !attachment_filename.empty())
+          if(strcmp(item->filename, attachment_filename.str) != 0) continue;
 
         file_errors.clear ();
 

--- a/pan/tasks/decoder.h
+++ b/pan/tasks/decoder.h
@@ -61,7 +61,8 @@ namespace pan
                     const strings_t                & input_files,
                     const TaskArticle::SaveMode    & save_mode,
                     const TaskArticle::SaveOptions & options,
-                    const StringView               & filename);
+                    const StringView               & filename,
+                    const Article                  & article);
 
     public:
 
@@ -82,6 +83,7 @@ namespace pan
       TaskArticle::SaveMode save_mode;
       TaskArticle::SaveOptions options;
       StringView attachment_filename;
+      Quark article_subject;
 
       // These are set in the worker thread and polled in the main thread.
       Mutex mut;

--- a/pan/tasks/task-article.cc
+++ b/pan/tasks/task-article.cc
@@ -350,7 +350,7 @@ TaskArticle :: use_decoder (Decoder* decoder)
   _state.set_working();
   const Article::mid_sequence_t mids (_article.get_part_mids());
   ArticleCache :: strings_t filenames (_cache.get_filenames (mids));
-  _decoder->enqueue (this, _save_path, filenames, _save_mode, _options, _attachment);
+  _decoder->enqueue (this, _save_path, filenames, _save_mode, _options, _attachment, _article);
   set_status_va (_("Decoding %s"), _article.subject.c_str());
   debug ("decoder thread was free, enqueued work");
 }

--- a/uulib/uudeview.h
+++ b/uulib/uudeview.h
@@ -206,7 +206,7 @@ int	UUEXPORT UUSetFNameFilter	_ANSI_ARGS_((void *,
 								 char *)));
 char *	UUEXPORT UUFNameFilter		_ANSI_ARGS_((char *));
 int	UUEXPORT UULoadFile		_ANSI_ARGS_((char *, char *, int));
-int	UUEXPORT UULoadFileWithPartNo	_ANSI_ARGS_((char *, char *, int, int));
+int	UUEXPORT UULoadFileWithPartNo	_ANSI_ARGS_((char *, char *, int, int, const char *));
 uulist *UUEXPORT UUGetFileListItem	_ANSI_ARGS_((int));
 int	UUEXPORT UURenameFile		_ANSI_ARGS_((uulist *, char *));
 int	UUEXPORT UUDecodeToTemp		_ANSI_ARGS_((uulist *));
@@ -227,7 +227,7 @@ int	UUEXPORT UUEncodeMulti		_ANSI_ARGS_((FILE *, FILE *,
 int	UUEXPORT UUEncodePartial	_ANSI_ARGS_((FILE *, FILE *,
 						     char *, int,
 						     char *, char *,
-						     int, int, long, unsigned long*));
+						     int, int, long, uint32_t*));
 int	UUEXPORT UUEncodePartial_byFSize	_ANSI_ARGS_((FILE *, FILE *,
 						     char *, int,
 						     char *, char *,


### PR DESCRIPTION
These changes to allow the file name given in the Subject of a task list
entry to be used instead of the one from the subject of the part(s) or
the one that may be included in the encoding format.